### PR TITLE
Fixes for -l option in navinfo.php and navqa.php

### DIFF
--- a/bin/navcopy.php
+++ b/bin/navcopy.php
@@ -156,7 +156,7 @@ function usage()
     echo "Rolling Deck To Repository (R2R): Navigation Manager\n";
     echo "Purpose: Convert raw nav data to the r2rnav standard format.\n";
     echo "\n";
-    echo "Usage: navcopy.php -i <input file> | -d <data_diretory> -f <format> -o <outifle> [-t <time range>] [-h]\n\n";
+    echo "Usage: navcopy.php -d <data_diretory> -f <format> -o <outifle> [-t <time range>] [-h]\n\n";
 	echo "Required:\n";
 	echo "\t-i <input file>\n";
 	echo "\t\tPath to directory containing raw navigation data.\n";

--- a/bin/navcopy.php
+++ b/bin/navcopy.php
@@ -156,7 +156,7 @@ function usage()
     echo "Rolling Deck To Repository (R2R): Navigation Manager\n";
     echo "Purpose: Convert raw nav data to the r2rnav standard format.\n";
     echo "\n";
-    echo "Usage: navcopy.php -d <data_diretory> -f <format> -o <outifle> [-t <time range>] [-h]\n\n";
+    echo "Usage: navcopy.php -i | <input file> -d <data_diretory> -f <format> -o <outifle> [-t <time range>] [-h]\n\n";
 	echo "Required:\n";
 	echo "\t-i <input file>\n";
 	echo "\t\tPath to directory containing raw navigation data.\n";

--- a/bin/navinfo.php
+++ b/bin/navinfo.php
@@ -94,20 +94,25 @@ if ($debug) {
 
 	$bounds = @navbounds($navInfoFile);
 
-
-	echo "\n";
-	echo "Navigation Start/End Info:\n";
-	echo "\tStart Date:\t", $dateStringUTCStart, "\n"; 
-	echo "\tEnd Date:\t", $dateStringUTCEnd, "\n"; 
-	echo "\tStart Lat/Lon:\t[", $portLatitudeStart, ",", $portLongitudeStart, "]\n"; 
-	echo "\tEnd Lat/Lon:\t[", $portLatitudeEnd, ",", $portLongitudeEnd, "]\n"; 
-	echo "\n";
-	echo "Navigation Bounding Box Info:\n";
-	echo "\tMinimum Longitude:\t", $bounds->westBoundLongitude, "\n"; 
-	echo "\tMaximum Longitude:\t", $bounds->eastBoundLongitude, "\n"; 
-	echo "\tMinimum Latitude:\t", $bounds->southBoundLatitude, "\n"; 
-	echo "\tMaximum Latitude:\t", $bounds->northBoundLatitude, "\n"; 
-
+    $output = '';
+    $output = $output . "Navigation Start/End Info:\n";
+    $output = $output . "\tStart Date:\t" . $dateStringUTCStart . "\n"; 
+    $output = $output . "\tEnd Date:\t" . $dateStringUTCEnd . "\n"; 
+    $output = $output . "\tStart Lat/Lon:\t[" . $portLatitudeStart . "," . $portLongitudeStart . "]\n"; 
+    $output = $output . "\tEnd Lat/Lon:\t[" . $portLatitudeEnd . "," . $portLongitudeEnd . "]\n"; 
+    $output = $output . "\n";
+    $output = $output . "Navigation Bounding Box Info:\n";
+    $output = $output . "\tMinimum Longitude:\t" . $bounds->westBoundLongitude . "\n";
+    $output = $output . "\tMaximum Longitude:\t" . $bounds->eastBoundLongitude . "\n";
+    $output = $output . "\tMinimum Latitude:\t" . $bounds->southBoundLatitude . "\n";
+    $output = $output . "\tMaximum Latitude:\t" . $bounds->northBoundLatitude . "\n";
+	
+	if ($fqalog != null) {
+		fwrite($fqalog, $output);
+		fclose($fqalog);
+	} else {
+        echo $output;
+	}
 
 #var_dump($qaNavigationRaw);
 /**

--- a/bin/navinfo.php
+++ b/bin/navinfo.php
@@ -14,7 +14,8 @@ $opts = getopts(
     array(
         'i' => array('switch' => array('i', 'infile'), 'type' => GETOPT_VAL),
         'h' => array('switch' => array('h', 'help'), 'type' => GETOPT_SWITCH),
-        'l' => array('switch' => array('l', 'log'), 'type' => GETOPT_VAL),
+        'l' => array('switch' => array('l', 'logfile'), 'type' => GETOPT_VAL),
+        'j' => array('switch' => array('j', 'jsonfile'), 'type' => GETOPT_VAL),
     ), $argv
 );
 
@@ -48,6 +49,18 @@ if ($opts['l']) {
 	$fqalog = null;
 }
 
+if ($opts['j']) {
+    $qajsonfile = trim($opts['j']);
+    $fqajson = fopen($qajsonfile, 'w');
+    if ($fqajson == null) {
+        echo "navinfo: Could not open json file for writing: "
+            . $qajsonfile . "\n";
+        exit(1);
+    }
+} else {
+	$fqajson = null;
+}
+
 if ($syntaxErr != "") {
     usage();
     echo $syntaxErr;
@@ -63,7 +76,7 @@ if ($syntaxErr != "") {
 
 // DEBUG stuff
 
-$debug = '';
+$debug = false;
 
 if ($debug) {
 	echo "\n";
@@ -94,24 +107,33 @@ if ($debug) {
 
 	$bounds = @navbounds($navInfoFile);
 
+    $startStop = (object) array('startTimestamp' => $dateStringUTCStart, 'endTimestamp' => $dateStringUTCStart, 'startLatLon' => array($portLatitudeStart,$portLongitudeStart), 'endLatLon' => array($portLatitudeEnd, $portLongitudeEnd));
+    
+    $outputObj = (object) array('startStop' => $startStop, 'boundingBox' => $bounds);
+
     $output = '';
     $output = $output . "Navigation Start/End Info:\n";
-    $output = $output . "\tStart Date:\t" . $dateStringUTCStart . "\n"; 
-    $output = $output . "\tEnd Date:\t" . $dateStringUTCEnd . "\n"; 
-    $output = $output . "\tStart Lat/Lon:\t[" . $portLatitudeStart . "," . $portLongitudeStart . "]\n"; 
-    $output = $output . "\tEnd Lat/Lon:\t[" . $portLatitudeEnd . "," . $portLongitudeEnd . "]\n"; 
+    $output = $output . "\tStart Date:\t" . $outputObj->startStop->startTimestamp . "\n"; 
+    $output = $output . "\tEnd Date:\t" . $outputObj->startStop->endTimestamp . "\n"; 
+    $output = $output . "\tStart Lat/Lon:\t[" . $outputObj->startStop->startLatLon[0] . "," . $outputObj->startStop->startLatLon[1] . "]\n"; 
+    $output = $output . "\tEnd Lat/Lon:\t[" . $outputObj->startStop->endLatLon[0] . "," . $outputObj->startStop->endLatLon[1] . "]\n"; 
     $output = $output . "\n";
     $output = $output . "Navigation Bounding Box Info:\n";
-    $output = $output . "\tMinimum Longitude:\t" . $bounds->westBoundLongitude . "\n";
-    $output = $output . "\tMaximum Longitude:\t" . $bounds->eastBoundLongitude . "\n";
-    $output = $output . "\tMinimum Latitude:\t" . $bounds->southBoundLatitude . "\n";
-    $output = $output . "\tMaximum Latitude:\t" . $bounds->northBoundLatitude . "\n";
+    $output = $output . "\tMinimum Longitude:\t" . $outputObj->boundingBox->westBoundLongitude . "\n";
+    $output = $output . "\tMaximum Longitude:\t" . $outputObj->boundingBox->eastBoundLongitude . "\n";
+    $output = $output . "\tMinimum Latitude:\t" . $outputObj->boundingBox->southBoundLatitude . "\n";
+    $output = $output . "\tMaximum Latitude:\t" . $outputObj->boundingBox->northBoundLatitude . "\n";
 	
 	if ($fqalog != null) {
 		fwrite($fqalog, $output);
 		fclose($fqalog);
 	} else {
         echo $output;
+	}
+
+    if ($fqajson != null) {
+		fwrite($fqajson, json_encode($outputObj));
+		fclose($fqajson);
 	}
 
 #var_dump($qaNavigationRaw);
@@ -125,7 +147,7 @@ function usage()
     echo "Rolling Deck To Repository (R2R): Navigation Manager\n";
     echo "Purpose: Get basic info on an r2rnav file.\n";
     echo "\n";
-    echo "Usage: navinfo.php -i <infile> [-l <logfile>] [-h]\n";
+    echo "Usage: navinfo.php -i <infile> [-l <logfile>] [-j <jsonfile>] [-h]\n";
     echo "\n";
     
 } // end function usage()

--- a/bin/navqa.php
+++ b/bin/navqa.php
@@ -16,7 +16,8 @@ $opts = getopts(
         'v' => array('switch' => array('v', 'max_speed'), 'type' => GETOPT_VAL),
         'a' => array('switch' => array('a', 'max_accel'), 'type' => GETOPT_VAL),
         'g' => array('switch' => array('g', 'max_gap'), 'type' => GETOPT_VAL),
-        'l' => array('switch' => array('l', 'log'), 'type' => GETOPT_VAL),
+        'l' => array('switch' => array('l', 'logfile'), 'type' => GETOPT_VAL),
+        'j' => array('switch' => array('j', 'jsonfile'), 'type' => GETOPT_VAL),
         'h' => array('switch' => array('h', 'help'), 'type' => GETOPT_SWITCH),
     ), $argv
 );
@@ -51,6 +52,19 @@ if ($opts['l']) {
 } else {
 	$fqalog = null;
 }
+
+if ($opts['j']) {
+    $qajsonfile = trim($opts['j']);
+    $fqajson = fopen($qajsonfile, 'w');
+    if ($fqajson == null) {
+        echo "navqa: Could not open json file for writing: "
+            . $qajsonfile . "\n";
+        exit(1);
+    }
+} else {
+	$fqajson = null;
+}
+
 
 if ($opts['v']) {
 	$speedHoriMax = trim($opts['v']);
@@ -130,7 +144,7 @@ if ($debug) {
 
     $output = '';
     $output = "Duration and range of values:\n" . $output;
-    $output =  $output . "\tEpoch Interval [" . $qaNavigationRaw->duration_and_range_of_values->Epoch_Interval->value . "]: " . $qaNavigationRaw->duration_and_range_of_values->Epoch_Interval->uom . "\n";
+    $output =  $output . "\tEpoch Interval [" . $qaNavigationRaw->duration_and_range_of_values->Epoch_Interval->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Epoch_Interval->value . "\n";
     $output =  $output . "\tMaximum Altitude [" . $qaNavigationRaw->duration_and_range_of_values->Maximum_Altitude->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Maximum_Altitude->value . "\n";
     $output =  $output . "\tMinimum Altitude [" . $qaNavigationRaw->duration_and_range_of_values->Minimum_Altitude->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Minimum_Altitude->value . "\n";
     $output =  $output . "\tMaximum Horizontal Speed [" . $qaNavigationRaw->duration_and_range_of_values->Maximum_Horizontal_Speed->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Maximum_Horizontal_Speed->value . "\n";
@@ -167,6 +181,10 @@ if ($debug) {
 		echo $output;
 	}
 
+	if ($fqajson != null) {    
+        fwrite($fqajson, json_encode($qaNavigationRaw));
+		fclose($fqajson);
+	}
 
 #var_dump($qaNavigationRaw);
 /**
@@ -194,6 +212,8 @@ function usage()
 	echo "\t\tSpecify the maximum allowable time gap in data in seconds. Default: " . MAX_GAP . "\n\n";
 	echo "\t-l or --logfile <logfile>\n\n";
 	echo "\t\tSpecify a logfile for the qa report.\n\n";
+	echo "\t-j or --jsonfile <jsonfile>\n\n";
+	echo "\t\tSpecify a json file for the qa report.\n\n";
     echo "\t-h or --help\n\n";
     echo "\t\tShow this help message.\n\n";
     echo "\n";

--- a/bin/navqa.php
+++ b/bin/navqa.php
@@ -81,7 +81,7 @@ if ($syntaxErr != "") {
 
 // Get port start/end info from first/last line of file
 
-		$if = fopen($navBestResPreQC, r);
+		$if = fopen($navBestResPreQC, 'r');
 
 		$headerPattern =  preg_quote(HEADER, '/');
 		$firstLine = firstLine($if, $headerPattern);
@@ -100,7 +100,7 @@ if ($syntaxErr != "") {
 
 // DEBUG stuff
 
-$debug = 'TRUE';
+$debug = false;
 
 if ($debug) {
 	echo "\n";
@@ -115,11 +115,7 @@ if ($debug) {
 	echo "\tDeparture Port Latitude:  ", $portLatitudeStart, "\n";
 	echo "\tArrival Port Longitude:   ", $portLongitudeEnd, "\n";
 	echo "\tArrival Port Latitude:    ", $portLatitudeEnd, "\n";
-	if ($fqalog != null) {
-		echo "\tLog file:                 ", $qalogfile, "\n";
-	} else {
-		echo "\tLog file:                none\n";
-	}   
+    echo "\tLog file:                 ", ($opts['l']? $qalogfile: "none"), "\n";
 }
 
 // END DEBUG stuff
@@ -132,7 +128,44 @@ if ($debug) {
 		$fqalog
 	);
 
-	var_dump($qaNavigationRaw);
+    $output = '';
+    $output = "Duration and range of values:\n" . $output;
+    $output =  $output . "\tEpoch Interval [" . $qaNavigationRaw->duration_and_range_of_values->Epoch_Interval->value . "]: " . $qaNavigationRaw->duration_and_range_of_values->Epoch_Interval->uom . "\n";
+    $output =  $output . "\tMaximum Altitude [" . $qaNavigationRaw->duration_and_range_of_values->Maximum_Altitude->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Maximum_Altitude->value . "\n";
+    $output =  $output . "\tMinimum Altitude [" . $qaNavigationRaw->duration_and_range_of_values->Minimum_Altitude->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Minimum_Altitude->value . "\n";
+    $output =  $output . "\tMaximum Horizontal Speed [" . $qaNavigationRaw->duration_and_range_of_values->Maximum_Horizontal_Speed->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Maximum_Horizontal_Speed->value . "\n";
+    $output =  $output . "\tMinimum Horizontal Speed [" . $qaNavigationRaw->duration_and_range_of_values->Minimum_Horizontal_Speed->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Minimum_Horizontal_Speed->value . "\n";
+    $output =  $output . "\tMaximum Horizontal Acceleration [" . $qaNavigationRaw->duration_and_range_of_values->Maximum_Horizontal_Acceleration->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Maximum_Horizontal_Acceleration->value . "\n";
+    $output =  $output . "\tMinimum Horizontal Acceleration [" . $qaNavigationRaw->duration_and_range_of_values->Minimum_Horizontal_Acceleration->uom . "]: " . $qaNavigationRaw->duration_and_range_of_values->Minimum_Horizontal_Acceleration->value . "\n";
+    $output =  $output . "\tDistance from Port Start: " . $qaNavigationRaw->duration_and_range_of_values->distanceFromPortStart . "\n";
+    $output =  $output . "\tDistance from Port End: " . $qaNavigationRaw->duration_and_range_of_values->distanceFromPortStart . "\n";
+    $output =  $output . "\tFirst Epoch: " . $qaNavigationRaw->duration_and_range_of_values->First_Epoch . "\n";
+    $output =  $output . "\tLast Epoch: " . $qaNavigationRaw->duration_and_range_of_values->Last_Epoch . "\n";
+    $output =  $output . "\tPossible Number of Epochs with Observations: " . $qaNavigationRaw->duration_and_range_of_values->Possible_Number_of_Epochs_with_Observations . "\n";
+    $output =  $output . "\tActual Number of Epochs with Observations: " . $qaNavigationRaw->duration_and_range_of_values->Actual_Number_of_Epochs_with_Observations . "\n";
+    $output =  $output . "\tActual Countable Number of Epoch with Observations: " . $qaNavigationRaw->duration_and_range_of_values->Actual_Countable_Number_of_Epoch_with_Observations . "\n";
+    $output =  $output . "\tAbsent Number of Epochs with Observations: " . $qaNavigationRaw->duration_and_range_of_values->Absent_Number_of_Epochs_with_Observations . "\n";
+    $output =  $output . "\tFlagged Number of Epochs with Observations: " . $qaNavigationRaw->duration_and_range_of_values->Flagged_Number_of_Epochs_with_Observations . "\n";
+    $output =  $output . "\tMaximum Number of Satellites: " . $qaNavigationRaw->duration_and_range_of_values->Maximum_Number_of_Satellites . "\n";
+    $output =  $output . "\tMinimum Number of Satellites: " . $qaNavigationRaw->duration_and_range_of_values->Minimum_Number_of_Satellites . "\n";
+    $output =  $output . "\tMaximum HDOP: " . $qaNavigationRaw->duration_and_range_of_values->Maximum_HDOP . "\n";
+    $output =  $output . "\tMinimum HDOP: " . $qaNavigationRaw->duration_and_range_of_values->Minimum_HDOP . "\n";
+    $output =  $output . "\n";
+    $output =  $output . "Quality Assessment:\n";
+    $output =  $output . "\tLongest Epoch Gap [" . $qaNavigationRaw->quality_assessment->longest_epoch_gap->uom . "]: " . $qaNavigationRaw->quality_assessment->longest_epoch_gap->value . "\n";
+    $output =  $output . "\tNumber of Gaps Longer than Threshold: " . $qaNavigationRaw->quality_assessment->number_of_gaps_longer_than_threshold . "\n";
+    $output =  $output . "\tNumber of Epochs Out of Sequence: " . $qaNavigationRaw->quality_assessment->number_of_epochs_out_of_sequence . "\n";
+    $output =  $output . "\tNumber of Epochs with Bad GPS Quality Indicator: " . $qaNavigationRaw->quality_assessment->number_of_epochs_with_bad_gps_quality_indicator . "\n";
+    $output =  $output . "\tNumber of Horizontal Speeds Exceeding Threshold: " . $qaNavigationRaw->quality_assessment->number_of_horizontal_speeds_exceeding_threshold . "\n";
+    $output =  $output . "\tNumber of Horizontal Accelerations Exceeding Threshold: " . $qaNavigationRaw->quality_assessment->number_of_horizontal_accelerations_exceeding_threshold . "\n";
+    $output =  $output . "\tPercent Completeness: " . $qaNavigationRaw->quality_assessment->percent_completeness . "\n";
+
+	if ($fqalog != null) {    
+        fwrite($fqalog, $output);
+		fclose($fqalog);
+	} else {
+		echo $output;
+	}
 
 
 #var_dump($qaNavigationRaw);

--- a/bin/navqc.php
+++ b/bin/navqc.php
@@ -53,22 +53,23 @@ if ($opts['l']) {
 		echo "navmanager: Could not open log file for writing: "
 			. $qclogfile . "\n";
 		exit(1);
-	}   
+	}
 } else {
 	$fqclog = null;
 }
 
-if ($opts['v']) {
-    $speedHoriMax = trim($opts['v']);
+if ($opts['v'] == null) {
+    $speedHoriMax = floatval(MAX_SPEED);
 } else {
-    $speedHoriMax = MAX_SPEED;
+    $speedHoriMax = floatval(trim($opts['v']));
 }
 
-if ($opts['a']) {
-    $accelHoriMax = trim($opts['a']);
+if ($opts['a'] == null) {
+    $accelHoriMax = floatval(MAX_ACCEL);
 } else {
-    $accelHoriMax = MAX_ACCEL;
+    $accelHoriMax = floatval(trim($opts['a']));
 }
+
 
 if ($syntaxErr != "") {
     usage();

--- a/bin/navqc.php
+++ b/bin/navqc.php
@@ -80,7 +80,7 @@ if ($syntaxErr != "") {
 
 // Get port start/end info from first/last line of file
 
-		$if = fopen($navBestResPreQC, r);
+		$if = fopen($navBestResPreQC, 'r');
 
 		$headerPattern =  preg_quote(HEADER, '/');
 		$firstLine = firstLine($if, $headerPattern);

--- a/include/navcopy.inc.php
+++ b/include/navcopy.inc.php
@@ -601,7 +601,10 @@ function navcopy($inputFormatSpec, $path, $navfilelist, $outfile)
 
                                         $delt = $gpsBuffer[$inx+1]->gga->hhmmss - $gpsBuffer[$inx]->gga->hhmmss;
                                     
-                                        if ($gpsBuffer[$inx+1]->gga->hhmmss < $gpsBuffer[$inx]->gga->hhmmss && $delt < -100000) {
+										// Added for Falkor to skip duplicate records caused by rounding seconds CJO 
+										if ($delt == 0) {
+											continue;
+                                        } elseif ($gpsBuffer[$inx+1]->gga->hhmmss < $gpsBuffer[$inx]->gga->hhmmss && $delt < -100000) {
                                             // Date has advanced.  Convert date to unix time, add 1 day, 
                                             // and convert back to date:
                                             $dateUnix = strtotime("+1 day", gmmktime(0, 0, 0, $gpsBuffer[$inx]->gga->month, $gpsBuffer[$inx]->gga->day, $gpsBuffer[$inx]->gga->year));
@@ -670,8 +673,11 @@ function navcopy($inputFormatSpec, $path, $navfilelist, $outfile)
                 //if ($isSamePCDay) {  // HACK for PE13-30, PE14-05 (gaps > 1 day)
  
                     $delt = $gpsBuffer[$inx+1]->gga->hhmmss - $gpsBuffer[$inx]->gga->hhmmss;
-                
-                    if ($gpsBuffer[$inx+1]->gga->hhmmss < $gpsBuffer[$inx]->gga->hhmmss && $delt < -100000) {
+              
+					// Added for Falkor to skip duplicate records caused by rounding seconds CJO 
+					if ($delt == 0) {
+						continue;
+                    } elseif ($gpsBuffer[$inx+1]->gga->hhmmss < $gpsBuffer[$inx]->gga->hhmmss && $delt < -100000) {
                         // Date has advanced.  Convert date to unix time, add 1 day, 
                         // and convert back to date:
                         $dateUnix = strtotime( "+1 day", gmmktime(0, 0, 0, $gpsBuffer[$inx]->gga->month, $gpsBuffer[$inx]->gga->day, $gpsBuffer[$inx]->gga->year) );
@@ -5441,6 +5447,110 @@ function navcopy($inputFormatSpec, $path, $navfilelist, $outfile)
 		} // end if (isset())
 		break;
 
+
+	// Parser for general csvs, just have to point to the correct columns
+	// This was made to parse .elg files from Endeavor cruises where the nave went missing
+    case "nav26":
+        
+        //----------- Initialize variables: -----------//    
+        $dateBufferLast = null;  // Initially unknown date.
+        
+        // Need to loop over all nav files in a cruise, in the order specified
+        // by external control file.
+        foreach ($navfilelist as $line) {
+
+            if ($line == "") break;
+            $filename = $path . "/" . $line;
+            $fid = fopen($filename, 'r');
+            
+            $inx = 1;  // Record index
+            //----------- Loop Over Contents of Single File ----------//
+            while (!feof($fid)) {
+                
+                $line = trim(fgets($fid));
+                
+                if (($inx > 1)  && ($line != "")) {  // Skip over header record and any blank lines.
+
+					$NavRec = preg_split("/\,/", $line);  // comma-separated values
+
+
+					if (count($NavRec) > 15) {
+
+						$dateRec = preg_split("/\-/", $NavRec[0]);  // values separated by dash "-"
+
+						$month = $dateRec[0];
+						$day = $dateRec[1];
+						$year = $dateRec[2];
+
+						$hour = substr($NavRec[11], 0, 2); 
+						$min = substr($NavRec[11], 2, 2); 
+						$sec = substr($NavRec[11], 4);
+                    
+                            
+                            if (preg_match("/\./", $sec)) {
+                                $roz = preg_split('/\./', $sec);
+                                $tim_nroz = strlen($roz[1]);
+                            } else {
+                                $tim_nroz = 0;
+                            }
+                            
+                            // Print exactly the same precision time stamp as in the recorded data.
+                            if ($tim_nroz == 0) {
+                                $time_format = "%4d-%02d-%02dT%02d:%02d:%02dZ";
+                            } else {
+                                $time_format = "%4d-%02d-%02dT%02d:%02d:%0" . ($tim_nroz + 3) . "." . $tim_nroz . "fZ";
+                            }
+                            
+                            $lat = $NavRec[12];
+                            $lon = $NavRec[13];
+                            $qual = $NavRec[14];
+                            $nsat = $NavRec[15];
+                            $hdop = $NavRec[16];
+                            
+                            // Determine the number of digits to the right of the decimal (lon):
+                            $roz = preg_split("/\./", $lon);
+                            $lon_nroz = strlen($roz[1]);
+                            
+                            // Determine the number of digits to the right of the decimal (lat):
+                            $roz = preg_split("/\./", $lat);
+                            $lat_nroz = strlen($roz[1]);
+                            
+                            // Preserve the precision of the original decimal longitude and latitude:
+                            $lon_format = "%." . $lon_nroz . "f";
+                            $lat_format = "%." . $lat_nroz . "f";
+                            
+                            // Format for quality info:
+                            $qual_format = "%s\t%s\t%s";
+                            
+                            // This format does not record altitude.  Fill in with "NAN".
+                            $alt  = "NAN";
+                            
+                            $datestamp = sprintf( $time_format, $year, $month, $day, $hour, $min, 
+                                                  $sec);
+                            
+                            $print_format = "%s\t" . $lon_format . "\t" . $lat_format . "\t" .
+                                $qual_format . "\t%s\n";
+                            
+                            fprintf(
+                                $fout, $print_format,
+                                $datestamp, $lon, $lat,
+                                $qual, $nsat, $hdop, $alt
+                            );
+                            
+                        
+					} // end if not header record
+
+				} // end if NavRec length is too short
+                
+                $inx++;
+                
+            } //end while (!feof($fid))
+            
+            fclose($fid);
+            
+        } // end foreach($navfilelist as $line)
+        //------------ End Main Loop Over All Nav Files ------------//
+        break;
 
 
     case "uhdas": 

--- a/include/navdatalist.inc.php
+++ b/include/navdatalist.inc.php
@@ -2395,6 +2395,146 @@ function navdatalist(
             } // end loop over files in dir
             break;
 
+        case "nav26":   
+     
+            // Initialize the row index for the table of nav files.  The table will 
+            // contain the start and end times of the data within each file and the 
+            // filename.  The table will be sorted from earliest to latest start
+            // times.
+            $inx = 0; 
+            $jnx = 0; 
+            while (false !== ($file = readdir($handle))) {
+     
+                if ($file != "." && $file != "..") {
+     
+                    $filename = $file;
+                    $fid = fopen($path . "/" . $filename, 'r');
+     
+                    //----------- Loop Over Contents of Single File ----------//
+                    while (!feof($fid)) {
+
+						$line = fgets($fid);
+
+                        // comma-separated values
+                        $NavRec = preg_split("/\,/", $line);
+
+                        // values separated by dash "-"
+                        $dateRec = preg_split("/-/", $NavRec[0]);
+                        // values separated by colon ":"
+                        $timeRec = preg_split("/\:/", $NavRec[1]);
+
+                        // Decode the date and time and the time precision:
+                        $month = $dateRec[0];
+                        $day   = $dateRec[1];
+                        $year  = $dateRec[2];
+
+                        $hour   = $timeRec[0];
+                        $minute = $timeRec[1];
+                        $second = $timeRec[2];
+
+                        if (preg_match("/\./", $second)) {
+                            $roz = preg_split('/\./', $second);
+                            $tim_nroz = strlen($roz[1]);
+                        } else {
+                            $tim_nroz = 0;
+                        }
+
+                        // Print exactly the same precision time stamp
+                        // as in the recorded data.
+                        if ($tim_nroz == 0) {
+                            $time_format = "%4d-%02d-%02dT%02d:%02d:%02dZ";
+                        } else {
+                            $time_format = "%4d-%02d-%02dT%02d:%02d:%0"
+                                . ($tim_nroz + 3) . "." . $tim_nroz . "fZ";
+                        }
+
+						if (isset($year) && isset($month) && isset($day) && isset($hour) && isset($minute) && isset($second)) {
+							$dateStringUTCStartFile = sprintf(
+								$time_format, $year, $month, $day,
+								$hour, $minute, $second
+							);
+							break;
+						}
+
+                    } // end loop over file
+
+                    // Grab last complete data record from file:
+                    rewind($fid);
+                    $line = trim(lastLine($fid, "\n"));  // Windows line endings.
+                    fclose($fid);
+
+                    // Check to see if line contains a timestamp:
+                    if (preg_match("/[0-9]{2}\:[0-9]{2}\:[0-9]{2}/", $line)) {
+
+                        $NavRec = preg_split("/\,/", $line);
+
+                        // values separated by dash "-"
+                        $dateRec = preg_split("/-/", $NavRec[0]);
+                        // values separated by colon ":"
+                        $timeRec = preg_split("/\:/", $NavRec[1]);
+
+                        // Decode the date and time and the time precision:
+                        $month = $dateRec[0];
+                        $day   = $dateRec[1];
+                        $year  = $dateRec[2];
+
+                        $hour   = $timeRec[0];
+                        $minute = $timeRec[1];
+                        $second = $timeRec[2];
+
+                        if (preg_match("/\./", $second)) {
+                            $roz = preg_split('/\./', $second);
+                            $tim_nroz = strlen($roz[1]);
+                        } else {
+                            $tim_nroz = 0;
+                        }
+
+                        // Print exactly the same precision time stamp
+                        // as in the recorded data.
+                        if ($tim_nroz == 0) {
+                            $time_format = "%4d-%02d-%02dT%02d:%02d:%02dZ";
+                        } else {
+                            $time_format = "%4d-%02d-%02dT%02d:%02d:%0"
+                                . ($tim_nroz + 3) . "." . $tim_nroz . "fZ";
+                        }
+
+                        $dateStringUTCEndFile = sprintf(
+                            $time_format, $year, $month, $day,
+                            $hour, $minute, $second
+                        );
+
+                    } else {
+
+                        $dateStringUTCEndFile = $dateStringUTCStartFile;
+                    }
+
+                    // Check that the start/end date/times in each file overlap the 
+                    // start/end date/times entered on the command line:
+                    if (!( (strtotime($dateStringUTCEndFile) < strtotime($dateStringUTCStart) )
+                        || (strtotime($dateStringUTCStartFile) > strtotime($dateStringUTCEnd) ) )
+                    ) {
+
+                        $table[$inx]["start"] = strtotime($dateStringUTCStartFile);
+                        $table[$inx]["end"]   = strtotime($dateStringUTCEndFile);
+                        $table[$inx]["file"]  = $filename;
+                        $inx++;
+
+                    } else {
+
+                        $otherParseableFiles[$jnx]["start"]
+                          = strtotime($dateStringUTCStartFile);
+                        $otherParseableFiles[$jnx]["end"]
+                            = strtotime($dateStringUTCEndFile);
+                        $otherParseableFiles[$jnx]["file"] = $filename;
+                        $jnx++;
+
+                    } // end if within bounds
+
+                } // if file is not "." nor ".."
+
+            } // end loop over files in dir
+            break;
+
             
         case "Endeavor":
             

--- a/include/navqc.inc.php
+++ b/include/navqc.inc.php
@@ -613,7 +613,6 @@ function navqc(
                                                         sprintf($latFormat, $lat[$inx])); 
                                             }
                                         }
-/* Commented out by Webb Pinner
                                         if ($timeNROD[$jnx] > 0) {
                                             $epochRFC5424 = gmdate("Y-m-d\TH:i:s", $utim[$jnx]) . "." .
                                                 sprintf($secFracFormat, round(pow(10, $timeNROD[$jnx]) * ($utim[$jnx] - floor($utim[$jnx])))) . "Z";
@@ -638,21 +637,20 @@ function navqc(
                                                         sprintf($latFormat, $lat[$jnx]));
                                             }
                                         }
-*/ //Commented out by Webb Pinner
-                                        
+
                                     } // end if verbose
                                     //---------- END VERBOSE ------------//
-                                    
+
                                     // Insert code here to test if two successive speeds are unreasonable.
-                                    
+
                                     //} // if excessive speed
-                                    
+
                                     $vnx++;
-                                    
+
                                 } // end if epochOK
-                                
+
                             }  // end loop over utim
-                            
+
                             // If two successive speeds are unreasonable, then the middle position
                             // is flagged.
                             //	      $vnxMax = count($speedHori);

--- a/include/navqc.inc.php
+++ b/include/navqc.inc.php
@@ -65,6 +65,7 @@ function navqc(
     $maxIter = 3;  // Max num of iterations to loop through buffer,
                    // flagging positions
     //--------- End Initialize Variables ------------//
+
     
     if (!file_exists($infile)) {
         echo "navqc(): Could not locate file: " . $infile . "\n";
@@ -543,9 +544,10 @@ function navqc(
                             // May need to turn both for loops into while loops:
                             for ($inx=1; $inx<$inxMax; $inx++) {
                                 
-                                if ($epochOK[$inx]) {  // Skip flagged positions
+				// Flipped check - Webb Pinner
+                                if (!$epochOK[$inx]) {  // Skip flagged positions
                                     // Get index of next position that is ok:
-                                    
+
                                     for ($jnx=$inx+1; $jnx<$jnxMax;$jnx++) {
                                         if ($epochOK[$jnx]) {
                                             break;
@@ -578,9 +580,11 @@ function navqc(
                                     if ($verbose) {
                                         
                                         $secFormat = "%." . $timeNROD[$inx] . "f";
+/* Commented out by Webb Pinner
                                         fprintf($flog, "Excessive Speed: %s m/s, Time increment: %s sec\n",
                                                 sprintf("%.2f", $speedHori[$vnx]), 
                                                 sprintf($secFormat, ($utim[$jnx] - $utim[$inx])));
+*/ //Commented out by Webb Pinner
                                         $lonFormat = ($lon[$inx] != "NAN") ? ("%." . $lonNROD[$inx] . "f") : "%s";
                                         $latFormat = ($lat[$inx] != "NAN") ? ("%." . $latNROD[$inx] . "f") : "%s";
                                         $secFracFormat = "%0" . $timeNROD[$inx] . "d";
@@ -609,6 +613,7 @@ function navqc(
                                                         sprintf($latFormat, $lat[$inx])); 
                                             }
                                         }
+/* Commented out by Webb Pinner
                                         if ($timeNROD[$jnx] > 0) {
                                             $epochRFC5424 = gmdate("Y-m-d\TH:i:s", $utim[$jnx]) . "." .
                                                 sprintf($secFracFormat, round(pow(10, $timeNROD[$jnx]) * ($utim[$jnx] - floor($utim[$jnx])))) . "Z";
@@ -633,6 +638,7 @@ function navqc(
                                                         sprintf($latFormat, $lat[$jnx]));
                                             }
                                         }
+*/ //Commented out by Webb Pinner
                                         
                                     } // end if verbose
                                     //---------- END VERBOSE ------------//
@@ -1019,6 +1025,7 @@ function navqc(
                         $utim[$jnx], $lon[$jnx], $lat[$jnx]
                     );
                     $tvel[$vnx] = 0.5 * ( $utim[$jnx] + $utim[$inx] );
+
                     if ($speedHori[$vnx] > $speedLimit) {
                         if ($speedReasonableAll) {
                             $speedReasonableAll = false;


### PR DESCRIPTION
I found some bugs in navinfo and navqa where the results from the operations were not being written to the specified logfile.  Also added a properly formatted report for navqa() that is human readable and inline with the reporting style used elsewhere in the project.

Also added a -j <jsonfile> option to allows these programs to output machine-readable, JSON-formatted output files for use by downstream programs/scripts.

Added a -i <input file> option to navcopy.php.  This permits a single file to be processed vs all the files in a directory.  The -i and -d flags can not be called at the same time but one of them must be present.

Cheers,
-W
